### PR TITLE
Added ReST formatting of CoC header

### DIFF
--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -1,4 +1,5 @@
 Contributor Code of Conduct
+===========================
 
 As contributors and maintainers of this project, and in the interest of
 fostering an open and welcoming community, we pledge to respect all
@@ -37,7 +38,7 @@ This code of conduct applies both within project spaces and in public
 spaces when an individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may
-be reported by contacting a project maintainer at graffatcolmingov@gmail.com.  
+be reported by contacting a project maintainer at graffatcolmingov@gmail.com.
 All complaints will be reviewed and investigated and will
 result in a response that is deemed necessary and appropriate to the
 circumstances. Maintainers are obligated to maintain confidentiality


### PR DESCRIPTION
Minor tweak to formatting CoC heading so it renders as h1 in browsers (e.g. GitHub)