### PR TITLE
Building the docs is broken with sphinx 1.4.0

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -16,6 +16,8 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
+import sphinx_rtd_theme
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -84,7 +86,7 @@ html_theme = 'sphinx_rtd_theme'
 # html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-# html_theme_path = []
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ basepython = python3
 [testenv:docs]
 deps =
     sphinx>=1.3.0
+    sphinx_rtd_theme
 commands =
     sphinx-build -W -E -c source -b html source/ build/html
 


### PR DESCRIPTION
Hello,

With sphinx 1.4.0 I've got this error while trying to build the documentation:

    Theme error:
    sphinx_rtd_theme is no longer a hard dependency since version 1.4.0. Please install it manually.
    ERROR: InvocationError: '/home/psycojoker/code/doc/pycqa/.tox/docs/bin/sphinx-build -W -E -c source -b html source/ build/html'

This PR fix this issue.

Kind regards,