### PR TITLE
Add flake8-import-order to management list

### DIFF
--- a/source/management.rst
+++ b/source/management.rst
@@ -32,6 +32,11 @@
 
   * Laurent Peuch
 
+- Flake8-import-order Administrators:
+
+  * Alex Stapleton
+  * Phil Jones
+
 All projects in the PyCQA should have a Code of Conduct that they are willing
 to enforce.
 


### PR DESCRIPTION
Following the recent addition of the project to PyCQA.

(Also as this commit/pull request helps me learn how the PyCQA projects are managed).