### PR TITLE
Update Code of Conduct

### DIFF
--- a/source/code-of-conduct.rst
+++ b/source/code-of-conduct.rst
@@ -62,7 +62,7 @@ Enforcement
 ===========
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [code-quality@python.org]. All
+reported by contacting the project team at code-quality@python.org. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/source/code-of-conduct.rst
+++ b/source/code-of-conduct.rst
@@ -62,7 +62,7 @@ Enforcement
 ===========
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+reported by contacting the project team at [code-quality@python.org]. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
Currently the contact us email for the Code of Conduct is blank. This is to update the email with code-quality@python.org so developers with issues have an address to reach out to.