### PR TITLE
Add email addresses to code of conduct

### DIFF
--- a/source/code-of-conduct.rst
+++ b/source/code-of-conduct.rst
@@ -62,7 +62,8 @@ Enforcement
 ===========
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+reported by contacting a project team member: Ian Stapleton Cordasco <graffatcolmingov@gmail.com>, 
+Ian Lee <IanLee1521@gmail.com> or Florian Bruhin <me@the-compiler.org>. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
Fixes https://github.com/PyCQA/meta/issues/13 by adding the three team members who volunteered to be contacts.

Replaces and closes https://github.com/PyCQA/meta/pull/22.

@sigmavirus24 and @IanLee1521, I put the email addresses from your GitHub profile. Please comment if you'd like another there.
