### PR TITLE
Add info on Bandit's inclusion in PyCQA

### DIFF
--- a/source/history.rst
+++ b/source/history.rst
@@ -75,3 +75,11 @@ code-quality mailing list
 about a new release and the need for more contributors and maintainers. At
 that point, the organization extended an invitation for Laurent Peuch to join
 with both Baron and RedBaron. The transfer was completed on 2016 March 31.
+
+Bandit moves to the PyCQA organization
+======================================
+On 2018 February 26, the authors of Bandit `sent a request to the
+code-quality mailing list
+<https://mail.python.org/pipermail/code-quality/2018-February/000976.html>`_
+to accept Bandit from the OpenStack namespace to the PyCQA. The
+transfer was completed on 2018 May 2.

--- a/source/introduction.rst
+++ b/source/introduction.rst
@@ -53,7 +53,7 @@ under the PyCQA are all presently maintained by the following people:
 
   * `Gage Hugo <https://github.com/ghugo>`_
 
-  * `Ian Cordasco <https://github.com/sigmavirus24>`_
+  * `Ian Stapleton Cordasco <https://github.com/sigmavirus24>`_
 
   * `Luke Hinds <https://github.com/lukehinds>`_
 

--- a/source/introduction.rst
+++ b/source/introduction.rst
@@ -47,6 +47,16 @@ under the PyCQA are all presently maintained by the following people:
 
   * `Sylvain Thénault <https://github.com/sthenault>`_
 
+- `Bandit <https://github.com/pycqa/bandit>`_
+
+  * `Eric Brown <https://github.com/ericwb>`_
+
+  * `Gage Hugo <https://github.com/ghugo>`_
+
+  * `Ian Cordasco <https://github.com/sigmavirus24>`_
+
+  * `Luke Hinds <https://github.com/lukehinds>`_
+
 - `Baron <https://github.com/pycqa/baron>`_
 
   * `Laurent Peuch <https://github.com/Psycojoker>`_

--- a/source/management.rst
+++ b/source/management.rst
@@ -45,7 +45,7 @@
 
   * Eric Brown
   * Gage Hugo
-  * Ian Cordasco
+  * Ian Stapleton Cordasco
   * Luke Hinds
 
 All projects in the PyCQA should have a Code of Conduct that they are willing

--- a/source/management.rst
+++ b/source/management.rst
@@ -41,6 +41,13 @@
 
   * Łukasz Langa
 
+- Bandit Administrator(s):
+
+  * Eric Brown
+  * Gage Hugo
+  * Ian Cordasco
+  * Luke Hinds
+
 All projects in the PyCQA should have a Code of Conduct that they are willing
 to enforce.
 


### PR DESCRIPTION
Back in 2018 from February to May, Bandit was migrated from the
OpenStack organization to PyCQA. The docs should reflect that
history and also the contact information for that project.

Signed-off-by: Eric Brown <browne@vmware.com>