### PR TITLE
Add modernize and isort to PyCQA history

### DIFF
--- a/source/history.rst
+++ b/source/history.rst
@@ -83,3 +83,13 @@ code-quality mailing list
 <https://mail.python.org/pipermail/code-quality/2018-February/000976.html>`_
 to accept Bandit from the OpenStack namespace to the PyCQA. The
 transfer was completed on 2018 May 2.
+
+modernize joins PyCQA
+======================================
+On 2020 August 18, Thomas Grainger, as a maintainer of the project, requests that modernize be moved into the PyCQA organization.
+With the support of all project maintainers in place, the transfer was completed on 2020 August 23.
+
+isort joins PyCQA
+======================================
+On 2020 August 23, Timothy Crosley, the author of isort sent a request for the project to be moved into the PyCQA organization.
+The transfer was completed on the same day.


### PR DESCRIPTION
Adds isort and modernize (@graingert) to the the PyCQA history page: 

![isort_modernize_history_screenshot](https://user-images.githubusercontent.com/2090154/92417961-e95ec500-f119-11ea-8f6a-8137d629cf21.png)
